### PR TITLE
Add support for MySQL databases

### DIFF
--- a/db/repository_test.go
+++ b/db/repository_test.go
@@ -16,6 +16,17 @@ func TestRepository_CreatePostgres(t *testing.T) {
 	// Don't expect to be able to ping it. It doesn't exist.
 }
 
+func TestRepository_CreateMysql(t *testing.T) {
+	db, err := NewDatabase("mysql://localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db == nil {
+		t.Fatal("Db is nil")
+	}
+	// Don't expect to be able to ping it. It doesn't exist.
+}
+
 func TestRepository_InvalidURL(t *testing.T) {
 	_, err := NewDatabase("bo&gus:\\lala*&^%$/")
 	if err == nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: de645cbbcacc38431e29ef5614c73cd2cde0bc476d6825fb8571f092c80e9ac7
-updated: 2017-01-25T10:38:30.672254397Z
+hash: 40c9edd27e6b709babbc3979ca69e5dc080712cb99ce3167536e08671542abf8
+updated: 2017-02-08T12:00:28.146598511+08:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -16,6 +16,8 @@ imports:
   - metrics/prometheus
 - name: github.com/go-logfmt/logfmt
   version: d4327190ff838312623b09bfeb50d7c93c8d9c1d
+- name: github.com/go-sql-driver/mysql
+  version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/golang/protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,8 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
 - package: gopkg.in/yaml.v2
+- package: github.com/go-sql-driver/mysql
+  version: v1.3
 testImport:
 - package: gopkg.in/DATA-DOG/go-sqlmock.v1
   version: ~1.1.4


### PR DESCRIPTION
This allows connecting to a mysql db instance to collect metrics using mysql:// driver scheme

I need to expose mysql metrics generated via custom queries and this PR seem to work for me, but I have zero experience with mysql and golang so I'm not sure if this is the best driver, but it's on the golang wiki so should be good pick.