### PR TITLE
Run the queries and update gauges in the background

### DIFF
--- a/querying/service.go
+++ b/querying/service.go
@@ -3,7 +3,6 @@ package querying
 import (
 	"github.com/weaveworks/prometheus_sql_exporter/db"
 	"github.com/weaveworks/prometheus_sql_exporter/monitoring"
-	"net/http"
 )
 
 // Service - Registers queries against gauges
@@ -11,7 +10,6 @@ import (
 type Service interface {
 	Register(q db.IntQuery, g monitoring.NamedGauge)
 	UpdateAll() error
-	Handler(h http.Handler) http.Handler
 }
 
 // NewService - Create a new query service
@@ -38,16 +36,4 @@ func (s *svc) UpdateAll() error {
 
 func (s *svc) Register(q db.IntQuery, g monitoring.NamedGauge) {
 	s.registered[q] = g
-}
-
-func (s *svc) Handler(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := s.UpdateAll()
-		if err != nil {
-			w.WriteHeader(500)
-			w.Write([]byte(err.Error()))
-			return
-		}
-		h.ServeHTTP(w, r)
-	})
 }

--- a/querying/service_test.go
+++ b/querying/service_test.go
@@ -2,8 +2,6 @@ package querying
 
 import (
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -26,20 +24,6 @@ func TestService_DoesUpdateAll(t *testing.T) {
 
 	testSvc.UpdateAll()
 	if gauge1.i != 1 || gauge2.i != 2 {
-		t.Fatal("Gauge was not updated")
-	}
-}
-
-func TestService_DoesUpdateUponHandler(t *testing.T) {
-	gauge1 := &mockGauge{}
-	testSvc.Register(query1, gauge1)
-
-	ts := httptest.NewServer(testSvc.Handler(http.NotFoundHandler()))
-	defer ts.Close()
-
-	http.Get(ts.URL)
-
-	if gauge1.i != 1 {
 		t.Fatal("Gauge was not updated")
 	}
 }


### PR DESCRIPTION
It's quite possible for the battery of queries to take longer than
Prometheus is prepared to wait for its scrape request to
complete. Since the queries are run in the HTTP handler, when that
happens, Prometheus either gets a 500 response or times out, and
considers the pod as down.

Instead of running queries on every scrape, run them to a
schedule ("as often as every five seconds").